### PR TITLE
Improved mapping method.

### DIFF
--- a/autoload/cake.vim
+++ b/autoload/cake.vim
@@ -114,23 +114,27 @@ function! cake#init_buffer() "{{{
   endif
   " Cut an element partially. Argument is element name(,theme name).
   command! -n=1 -bang -buffer -bar -range Celement :<line1>,<line2>call g:cake.clip_element(<bang>0,<f-args>)
+
+  doautocmd User PluginCakephpInitializeAfter
 endfunction "}}}
 function! cake#map_commands() "{{{
   nnoremap <buffer> <silent> <Plug>CakeJump       :<C-u>call g:cake.smart_jump('n')<CR>
   nnoremap <buffer> <silent> <Plug>CakeSplitJump  :<C-u>call g:cake.smart_jump('s')<CR>
   nnoremap <buffer> <silent> <Plug>CakeVSplitJump :<C-u>call g:cake.smart_jump('v')<CR>
   nnoremap <buffer> <silent> <Plug>CakeTabJump    :<C-u>call g:cake.smart_jump('t')<CR>
-  if !hasmapto('<Plug>CakeJump')
-    nmap <buffer> gf <Plug>CakeJump
-  endif
-  if !hasmapto('<Plug>CakeSplitJump')
-    nmap <buffer> <C-w>f <Plug>CakeSplitJump
-  endif
-  if !hasmapto('<Plug>CakeVSplitJump')
-    exe 'nmap <buffer> ' . g:cakephp_keybind_vsplit_gf . ' <Plug>CakeVSplitJump'
-  endif
-  if !hasmapto('<Plug>CakeTabJump')
-    nmap <buffer> <C-w>gf <Plug>CakeTabJump
+  if !g:cakephp_no_default_keymappings
+    if !hasmapto('<Plug>CakeJump')
+      nmap <buffer> gf <Plug>CakeJump
+    endif
+    if !hasmapto('<Plug>CakeSplitJump')
+      nmap <buffer> <C-w>f <Plug>CakeSplitJump
+    endif
+    if !hasmapto('<Plug>CakeVSplitJump')
+      exe 'nmap <buffer> ' . g:cakephp_keybind_vsplit_gf . ' <Plug>CakeVSplitJump'
+    endif
+    if !hasmapto('<Plug>CakeTabJump')
+      nmap <buffer> <C-w>gf <Plug>CakeTabJump
+    endif
   endif
 endfunction "}}}
 function! cake#set_abbreviations() "{{{
@@ -2165,14 +2169,19 @@ function! cake#factory(path_app)
   endfunction "}}}
   function! self.gf(option) "{{{
     if a:option == 'n'
-      exec "normal! gf"
+      execute g:cakephp_gf_fallback_n
     elseif a:option == 's'
-      exec "normal! \<C-w>f"
+      execute g:cakephp_gf_fallback_s
     elseif a:option == 't'
-      exec "normal! \<C-w>gf"
+      execute g:cakephp_gf_fallback_t
     endif
   endfunction "}}}
   " ============================================================
+
+  function! self.normal(key) "{{{
+    let op = stridx(a:key, "\<Plug>") != -1 ? "normal" : "normal!"
+    execute op a:key
+  endfunction "}}}
 
   " Functions: dbext.vim interface
   " ============================================================

--- a/doc/cake.txt
+++ b/doc/cake.txt
@@ -507,6 +507,52 @@ VARIABLES						*cake-variables*
   let g:cakephp_app_config_file = '.project'
 <
 
+g:cakephp_no_default_keymappings           *g:cakephp_no_default_keymappings*
+
+		This plugin will define the following key mappings in Normal
+		mode automatically. If you don't want these key mappings,
+		define |g:cakephp_no_default_keymappings| before this plugin
+		is loaded (e.g. in your |vimrc|).
+
+		{lhs}	{rhs}
+		------	---------------------------
+		gf	<Plug>CakeJump
+		gs	<Plug>CakeVSplitJump
+		<C-w>f	<Plug>CakeSplitJump
+		<C-w>gf	<Plug>CakeTabJump
+
+
+		If you want to customize the key mapping, please use the
+		|PluginCakephpInitializeAfter| event with autocmd statement.
+		For example, the following code assign |<Plug>CakeJump| to
+		"gf".
+
+>
+	function! s:init_cakephp()
+		nmap <buffer> gf <Plug>CakeJump
+	endfunction
+	autocmd my-vimrc User PluginCakephpInitializeAfter call s:init_cakephp()
+<
+
+g:cakephp_gf_fallback_n                    *g:cakephp_gf_fallback_n*
+
+		If there is no cakephp file when <Plug>CakeJump is called,
+		|g:cakephp_gf_fallback_n| will be executed by |execute|.
+		(Default: "normal! gf")
+
+g:cakephp_gf_fallback_s                    *g:cakephp_gf_fallback_s*
+
+		If there is no cakephp file when <Plug>CakeSplitJump is called,
+		|g:cakephp_gf_fallback_s| will be executed by |execute|.
+		(Default: "normal! \<C-w>f")
+
+g:cakephp_gf_fallback_t                    *g:cakephp_gf_fallback_t*
+
+		If there is no cakephp file when <Plug>CakeTabJump is called,
+		|g:cakephp_gf_fallback_t| will be executed by |execute|.
+		(Default: "normal! \<C-w>gf")
+
+
 ==============================================================================
 BUGS								*cake-bugs*
 

--- a/plugin/cake.vim
+++ b/plugin/cake.vim
@@ -55,7 +55,10 @@ let g:cakephp_log                       = get(g:, 'cakephp_log', {
                                               \ 'query' : '/var/log/mysql/query.log',
                                               \ 'access': '/usr/local/apache2/logs/access_log'
                                               \ })
-
+let g:cakephp_no_default_keymappings    = get(g:, 'cakephp_no_default_keymappings', 0)
+let g:cakephp_gf_fallback_n              = get(g:, 'cakephp_gf_fallback_n', "normal! gf")
+let g:cakephp_gf_fallback_s              = get(g:, 'cakephp_gf_fallback_s', "normal! \<C-w>f")
+let g:cakephp_gf_fallback_t              = get(g:, 'cakephp_gf_fallback_t', "normal! \<C-w>gf")
 " }}}
 " SECTION: Auto commands {{{
 augroup detect_cakephp_project


### PR DESCRIPTION
マッピングの方式をちょっとだけ修正しましたので、よろしければマージをお願いいたします。

メインとなる変更は、autocmd による初期化時のマッピングのサポートと、g:cakephp_no_default_keymappings の追加です。
現状、mapping が ftplugin などからマッピングしている場合以外では、外から自由にマッピングできるようなインタフェースがサポートされていない、かつ、無効にすることもできないようだったので、
それができるように修正を加えています。デフォルトの挙動は特にかわっていないはずです。

あと、gf 周りもoption として指定できるように修正しています。
デフォルトの挙動は今までと同じなはずです。個人的には gf-user とかも使えるようになっていたほうが嬉しいので。(gf#user#extend で対応できればよかったのですが、ソースを確認した感じですと、一筋縄ではいかなそうだったのでやむを得ずという感じですね…)
オプションの値に normal! も含めているのは、<Plug> なマッピングがサポートできていないとあまり意味がないなかったためです。ちょっとダサイのですが、オプションに設定されている値を見て切り替えるよりも、直接指定してしまったほうが、わかりやすいし、自然だと思ったのでこうしています。

英語は苦手なのでちょっと変かもしれないですが、追加した箇所に関しての簡単な help も追記しております。
